### PR TITLE
Add output vpn_transit_gateway_attachment_id

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -99,4 +99,5 @@
 | <a name="output_vpn_connection_tunnel2_cgw_inside_address"></a> [vpn\_connection\_tunnel2\_cgw\_inside\_address](#output\_vpn\_connection\_tunnel2\_cgw\_inside\_address) | The RFC 6890 link-local address of the second VPN tunnel (Customer Gateway side) |
 | <a name="output_vpn_connection_tunnel2_vgw_inside_address"></a> [vpn\_connection\_tunnel2\_vgw\_inside\_address](#output\_vpn\_connection\_tunnel2\_vgw\_inside\_address) | The RFC 6890 link-local address of the second VPN tunnel (Virtual Private Gateway side) |
 | <a name="output_vpn_gateway_id"></a> [vpn\_gateway\_id](#output\_vpn\_gateway\_id) | Virtual Private Gateway ID |
+| <a name="output_vpn_transit_gateway_attachment_id"></a> [vpn\_transit\_gateway\_attachment\_id](#output\_vpn\_transit\_gateway\_attachment\_id) | Transit Gateway Attachment ID if it's enabled |
 <!-- markdownlint-restore -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -51,3 +51,7 @@ output "vpn_connection_tunnel2_vgw_inside_address" {
   value       = join("", aws_vpn_connection.default.*.tunnel2_vgw_inside_address)
 }
 
+output "vpn_transit_gateway_attachment_id" {
+  description = "Transit Gateway Attachment ID if it's enabled"
+  value       = var.transit_gateway_enabled ? join("", aws_vpn_connection.default.*.transit_gateway_attachment_id) : null
+}


### PR DESCRIPTION
## what

- Add output vpn_transit_gateway_attachment_id only if transit gateway is enabled.
- Update README.

## why

When working with VPN + Transit gateway the transit gateway attachment is needed to associate the VPN to the transit gateway route table, also needed if you need to add static routes.


