### PR TITLE
add sensitive true on gateway output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -15,6 +15,7 @@ output "vpn_connection_id" {
 
 output "vpn_connection_customer_gateway_configuration" {
   description = "The configuration information for the VPN connection's Customer Gateway (in the native XML format)"
+  sensitive   = true
   value = join(
     "",
     aws_vpn_connection.default.*.customer_gateway_configuration,


### PR DESCRIPTION
## what

Error on plan or apply code, because the output have a sensitive data.
Implementation uses this versions:
Terraform: v1.6.6
Terragrunt: v0.54.12
Cloudposse module version: latest (v0.9.0)

## why


Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Output refers to sensitive values
│ 
│   on outputs.tf line 16:
│   16: output "vpn_connection_customer_gateway_configuration" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true

## references

<!--
`closes #35`, if this PR closes a GitHub issue `#35`
