### PR TITLE
fix: added create_before_destroy argument for customer gateway

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,10 @@ resource "aws_customer_gateway" "default" {
   ip_address  = var.customer_gateway_ip_address
   type        = "ipsec.1"
   tags        = module.this.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 module "logs" {


### PR DESCRIPTION
## what

Added meta-argument `lifecycle` to `aws_customer_gateway.default` to create the resource before it gets destroyed when an argument update generates a resource replacement

## why

If the customer gateway needs to be replaced (for example, when attributes `bgp_asn` or `device_name` change), Terraform is unable to delete the resource because it is being used by the VPN connection and its updated substitute is not created beforehand:

```
aws_customer_gateway.default[0]: Destroying... [id=cgw-XXXXXXXXXXXXXXXXX]
╷
│ Error: deleting EC2 Customer Gateway (cgw-XXXXXXXXXXXXXXXXX): operation error EC2: DeleteCustomerGateway, https response error StatusCode: 400, RequestID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx, api error IncorrectState: The customer gateway is in use.
```
