### PR TITLE
Add support for dpd_timeout seconds and rekey_margin_time_seconds values

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,11 +71,12 @@ resource "aws_vpn_connection" "default" {
   local_ipv4_network_cidr  = var.vpn_connection_local_ipv4_network_cidr
   remote_ipv4_network_cidr = var.vpn_connection_remote_ipv4_network_cidr
 
-  tunnel1_dpd_timeout_action = var.vpn_connection_tunnel1_dpd_timeout_action
-  tunnel1_ike_versions       = var.vpn_connection_tunnel1_ike_versions
-  tunnel1_inside_cidr        = var.vpn_connection_tunnel1_inside_cidr
-  tunnel1_preshared_key      = var.vpn_connection_tunnel1_preshared_key
-  tunnel1_startup_action     = var.vpn_connection_tunnel1_startup_action
+  tunnel1_dpd_timeout_action  = var.vpn_connection_tunnel1_dpd_timeout_action
+  tunnel1_dpd_timeout_seconds = var.vpn_connection_tunnel1_dpd_timeout_seconds
+  tunnel1_ike_versions        = var.vpn_connection_tunnel1_ike_versions
+  tunnel1_inside_cidr         = var.vpn_connection_tunnel1_inside_cidr
+  tunnel1_preshared_key       = var.vpn_connection_tunnel1_preshared_key
+  tunnel1_startup_action      = var.vpn_connection_tunnel1_startup_action
 
   tunnel1_phase1_dh_group_numbers      = var.vpn_connection_tunnel1_phase1_dh_group_numbers
   tunnel1_phase2_dh_group_numbers      = var.vpn_connection_tunnel1_phase2_dh_group_numbers
@@ -85,6 +86,7 @@ resource "aws_vpn_connection" "default" {
   tunnel1_phase2_integrity_algorithms  = var.vpn_connection_tunnel1_phase2_integrity_algorithms
   tunnel1_phase1_lifetime_seconds      = var.vpn_connection_tunnel1_phase1_lifetime_seconds
   tunnel1_phase2_lifetime_seconds      = var.vpn_connection_tunnel1_phase2_lifetime_seconds
+  tunnel1_rekey_margin_time_seconds    = var.vpn_connection_tunnel1_rekey_margin_time_seconds
 
   tunnel1_log_options {
     cloudwatch_log_options {
@@ -94,11 +96,12 @@ resource "aws_vpn_connection" "default" {
     }
   }
 
-  tunnel2_dpd_timeout_action = var.vpn_connection_tunnel2_dpd_timeout_action
-  tunnel2_ike_versions       = var.vpn_connection_tunnel2_ike_versions
-  tunnel2_inside_cidr        = var.vpn_connection_tunnel2_inside_cidr
-  tunnel2_preshared_key      = var.vpn_connection_tunnel2_preshared_key
-  tunnel2_startup_action     = var.vpn_connection_tunnel2_startup_action
+  tunnel2_dpd_timeout_action  = var.vpn_connection_tunnel2_dpd_timeout_action
+  tunnel2_dpd_timeout_seconds = var.vpn_connection_tunnel2_dpd_timeout_seconds
+  tunnel2_ike_versions        = var.vpn_connection_tunnel2_ike_versions
+  tunnel2_inside_cidr         = var.vpn_connection_tunnel2_inside_cidr
+  tunnel2_preshared_key       = var.vpn_connection_tunnel2_preshared_key
+  tunnel2_startup_action      = var.vpn_connection_tunnel2_startup_action
 
   tunnel2_phase1_dh_group_numbers      = var.vpn_connection_tunnel2_phase1_dh_group_numbers
   tunnel2_phase2_dh_group_numbers      = var.vpn_connection_tunnel2_phase2_dh_group_numbers
@@ -108,6 +111,7 @@ resource "aws_vpn_connection" "default" {
   tunnel2_phase2_integrity_algorithms  = var.vpn_connection_tunnel2_phase2_integrity_algorithms
   tunnel2_phase1_lifetime_seconds      = var.vpn_connection_tunnel2_phase1_lifetime_seconds
   tunnel2_phase2_lifetime_seconds      = var.vpn_connection_tunnel2_phase2_lifetime_seconds
+  tunnel2_rekey_margin_time_seconds    = var.vpn_connection_tunnel2_rekey_margin_time_seconds
 
   tunnel2_log_options {
     cloudwatch_log_options {

--- a/variables.tf
+++ b/variables.tf
@@ -110,6 +110,15 @@ variable "vpn_connection_tunnel1_dpd_timeout_action" {
   nullable    = false
 }
 
+variable "vpn_connection_tunnel1_dpd_timeout_seconds" {
+  type        = string
+  description = <<-EOT
+    The number of seconds after which a DPD timeout occurs for the first VPN tunnel. 
+    Valid value is equal or higher than 30
+    EOT
+  default     = null
+}
+
 variable "vpn_connection_tunnel1_ike_versions" {
   type        = list(string)
   description = "The IKE versions that are permitted for the first VPN tunnel. Valid values are `ikev1` | `ikev2`"
@@ -197,6 +206,12 @@ variable "vpn_connection_tunnel1_phase2_lifetime_seconds" {
   nullable    = false
 }
 
+variable "vpn_connection_tunnel1_rekey_margin_time_seconds" {
+  type        = string
+  description = "The margin time, in seconds, before the phase 2 lifetime expires, during which the AWS side of the first VPN connection performs an IKE rekey."
+  default     = null
+}
+
 variable "vpn_connection_tunnel1_preshared_key" {
   type        = string
   description = "The preshared key of the first VPN tunnel. The preshared key must be between 8 and 64 characters in length and cannot start with zero. Allowed characters are alphanumeric characters, periods(.) and underscores(_)"
@@ -241,6 +256,15 @@ variable "vpn_connection_tunnel2_dpd_timeout_action" {
   description = "The action to take after DPD timeout occurs for the second VPN tunnel. Specify restart to restart the IKE initiation. Specify clear to end the IKE session. Valid values are `clear` | `none` | `restart`"
   default     = "clear"
   nullable    = false
+}
+
+variable "vpn_connection_tunnel2_dpd_timeout_seconds" {
+  type        = string
+  description = <<-EOT
+    The number of seconds after which a DPD timeout occurs for the first VPN tunnel. 
+    Valid value is equal or higher than 30
+    EOT
+  default     = null
 }
 
 variable "vpn_connection_tunnel2_ike_versions" {
@@ -328,6 +352,11 @@ variable "vpn_connection_tunnel2_phase2_lifetime_seconds" {
   description = "The lifetime for phase 2 of the IKE negotiation for the second VPN tunnel, in seconds. Valid value is between 900 and 3600"
   default     = "3600"
   nullable    = false
+}
+variable "vpn_connection_tunnel2_rekey_margin_time_seconds" {
+  type        = string
+  description = "The margin time, in seconds, before the phase 2 lifetime expires, during which the AWS side of the first VPN connection performs an IKE rekey."
+  default     = null
 }
 
 variable "vpn_connection_tunnel2_preshared_key" {


### PR DESCRIPTION
## what

This PR adds the support to be able to configure "dpd_timeout_seconds" and "rekey_margin_time_seconds" parameters of s2s vpn connections using this module.


## why

We are not using the default values for these parameters for our vpn connections and we would like to be able to change them accordingly.

## references

closes #72
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
